### PR TITLE
Remove favicon.png file and meta tag

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -54,12 +54,6 @@ IMAGE_FILES = {
     args: "-depth 8",
     destdir: ".",
   },
-  "favicon.png" => {
-    source: AVATAR_FILE,
-    size: [64, 64],
-    quality: 93,
-    args: "-depth 8",
-  },
   "cv-sarzyniec-en.jpg" => {
     source: RESUME_FILES[:pdf][:en],
     size: [300, 425],

--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -10,4 +10,3 @@
 
 <meta name="robots" content="index, follow" />
 <meta name="referrer" content="origin" />
-<link rel="icon" type="image/png" href="{{'assets/images/favicon.png' | relative_url}}" />


### PR DESCRIPTION
Browsers are trying to fetch it even if they already fetched favicon.ico,
that make the whole purpose of the file pointless and slow down page rendering.