### PR TITLE
Remove HTTP Public Key Pinning support (deprecated)

### DIFF
--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -4,7 +4,6 @@
 <meta http-equiv="Feature-Policy" content="geolocation 'none'; midi 'none'; notifications 'none'; push 'none'; microphone 'none'; camera 'none'; accelerometer 'none'; magnetometer 'none'; gyroscope 'none'; speaker 'none'; vibrate 'none'; payment 'none'; usb 'none'; vr 'none'; sync-xhr 'self'"/>
 <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin"/>
 
-<meta http-equiv="Public-Key-Pins-Report-Only" content='pin-sha256="xzyQeYHLztwo8SFf9pM2d1htw5it5sGkBYuAeleLlqA="; pin-sha256="lCppFqbkrlJ3EcVFAkeip0+44VaoJUymbnOaEUk7tEU="; pin-sha256="K87oWBWM9UZfyddvDfoxL+8lpNyoUB2ptGtn0fv6G2Q="; max-age=86400; report-uri="https://olbat.report-uri.com/r/d/hpkp/reportOnly"'/>
 <meta http-equiv="Expect-CT" content='max-age=86400, report-uri="https://olbat.report-uri.com/r/d/ct/reportOnly"'/>
 <meta http-equiv="Expect-Staple" content='max-age=86400, report-uri="https://olbat.report-uri.com/r/d/staple/reportOnly"'/>
 

--- a/scripts/cf-workers.js
+++ b/scripts/cf-workers.js
@@ -12,13 +12,6 @@ let headers = {
             "includeSubDomains",
             "preload",
         ].join("; "),
-        "Public-Key-Pins-Report-Only": [
-            'max-age=86400',
-            'pin-sha256="xzyQeYHLztwo8SFf9pM2d1htw5it5sGkBYuAeleLlqA="',
-            'pin-sha256="lCppFqbkrlJ3EcVFAkeip0+44VaoJUymbnOaEUk7tEU="',
-            'pin-sha256="K87oWBWM9UZfyddvDfoxL+8lpNyoUB2ptGtn0fv6G2Q="',
-            'report-uri="https://olbat.report-uri.com/r/d/hpkp/reportOnly"',
-        ].join("; "),
         "Expect-CT": [
             "max-age=86400",
             'report-uri="https://olbat.report-uri.com/r/d/ct/reportOnly"',


### PR DESCRIPTION
HPKP is deprecated for a while now: time to get rid of it
(see https://developer.mozilla.org/en-US/docs/Web/HTTP/Public_Key_Pinning)