### PR TITLE
Update the minimal-mistakes dependency to version 4.19.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,7 +76,7 @@ GEM
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.3.6)
     mini_portile2 (2.4.0)
-    minimal-mistakes-jekyll (4.19.2)
+    minimal-mistakes-jekyll (4.19.3)
       jekyll (>= 3.7, < 5.0)
       jekyll-feed (~> 0.1)
       jekyll-gist (~> 1.5)


### PR DESCRIPTION
Jekyll 4.1.0 breaks the build process because of a new buggy feature
related to page's excerpt that will be disabled by default in 4.1.1.

It won't be updated alongside with minimal-mistakes this time.