### PR TITLE
Remove dependency on custom jekyll-github-metadata version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,7 @@
 source "https://rubygems.org"
 
 gem "minimal-mistakes-jekyll", "~> 4.24.0"
-gem "jekyll-github-metadata", #"~> 2.16.0"
-  # this is a temporary hack as a repository that has been taken down makes
-  # jekyll-github-metadata fail to gather metadata
-  # TODO: use the stable library once the repository has been deleted
-  github: 'olbat/github-metadata', branch: 'ignore-repository-access-blocked-errors'
+gem "jekyll-github-metadata", "~> 2.16.0"
 
 group :production do
   gem "htmlcompressor", "~> 0.4.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,3 @@
-GIT
-  remote: https://github.com/olbat/github-metadata.git
-  revision: dffb5dc4789c0ca85958912654c1ebee2b48017d
-  branch: ignore-repository-access-blocked-errors
-  specs:
-    jekyll-github-metadata (2.16.1)
-      jekyll (>= 3.4, < 5.0)
-      octokit (>= 4, < 7, != 4.4.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -79,6 +70,9 @@ GEM
       jekyll (>= 3.7, < 5.0)
     jekyll-gist (1.5.0)
       octokit (~> 4.2)
+    jekyll-github-metadata (2.16.1)
+      jekyll (>= 3.4, < 5.0)
+      octokit (>= 4, < 7, != 4.4.0)
     jekyll-include-cache (0.2.1)
       jekyll (>= 3.7, < 5.0)
     jekyll-paginate (1.1.0)
@@ -175,7 +169,7 @@ PLATFORMS
 DEPENDENCIES
   html-proofer (~> 5.0.0)
   htmlcompressor (~> 0.4.0)
-  jekyll-github-metadata!
+  jekyll-github-metadata (~> 2.16.0)
   json-ld (~> 3.1.0)
   json-schema (~> 4.2.0)
   minimal-mistakes-jekyll (~> 4.24.0)


### PR DESCRIPTION
This custom version of the jekyll-github-metadata dependency is not needd anymore as the problematic repository that made this change necessary has been deleted.