### PR TITLE
Replace jQuery bundle with vanilla JS; drop minimal-mistakes submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "deps/minimal-mistakes"]
-	path = deps/minimal-mistakes
-	url = https://github.com/mmistakes/minimal-mistakes

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,17 +28,10 @@ WORKDIR /src
 VOLUME /src
 
 ENV NODE_PATH=/usr/local/lib/node_modules
-RUN npm install -g --unsafe-perm=true uncss uglify-js fa-minify trianglify@~3
+RUN npm install -g --unsafe-perm=true uncss uglify-js trianglify@~3
 
 RUN bundle config set --local system 'true'
 COPY Gemfile Gemfile.lock /src/
 RUN bundle install
-
-COPY deps/minimal-mistakes/package.json /src/
-RUN npm install
-
-# safeguard to make sure the git submodule is in sync
-RUN [ "$(bundle show minimal-mistakes-jekyll | awk -F- '{print $NF}')" \
-  = "$(jq -r '.version' package.json)" ]
 
 CMD bundle exec jekyll build

--- a/Rakefile
+++ b/Rakefile
@@ -2,6 +2,7 @@ require 'yaml'
 require 'json'
 require 'uri'
 require 'open-uri'
+require 'open3'
 require 'digest/sha2'
 require 'jekyll'
 require 'json/ld'
@@ -15,7 +16,6 @@ ICONS_DIR = "_includes/icons"
 JAVASCRIPT_DIR = "assets/js"
 STYLE_DIR = "assets/css"
 FILES_DIR = "files"
-MINIMAL_MISTAKES_DIR="deps/minimal-mistakes"
 
 JAVASCRIPT_FILE = File.join(JAVASCRIPT_DIR, "main.min.js")
 STYLESHEET_FILE = File.join(STYLE_DIR, "main.css")
@@ -23,10 +23,6 @@ JAVASCRIPT_MAIN_FILE = File.join(JAVASCRIPT_DIR, "_main.js")
 BANNER_FILE = File.join(FILES_DIR, "misc", "banner.svg")
 AVATAR_FILE = File.join(FILES_DIR, "misc", "avatar.png")
 IDENTITY_FILE = "identities.yml"
-MINIMAL_MISTAKES_EXCLUDED_SCRIPTS = [
-  'jquery.magnific-popup.js',
-  'jquery.fitvids.js',
-]
 RESUME_FILES = {
   :pdf => {
     :en => File.join(FILES_DIR, "misc", "cv-sarzyniec.pdf"),
@@ -116,45 +112,25 @@ end
 namespace :build do
   namespace :generate do
     namespace :javascript do
-      desc "Substitute `@@ICON:<name>@@` placeholders in _main.js with inline SVGs"
-      # writes the transformed file into the minimal-mistakes build dir; the
-      # `main` task picks it up from there and feeds it to uglify.
-      task :inline_icons => ['generate:icons'] do
+      desc "Inline `@@ICON:<name>@@` placeholders from _main.js and write a minified #{JAVASCRIPT_FILE}"
+      task :main => ['generate:icons'] do
         placeholder = /'@@ICON:([a-z0-9-]+)@@'/
         src = File.read(JAVASCRIPT_MAIN_FILE)
         src.scan(placeholder).flatten.uniq.each do |name|
           abort "unknown icon '#{name}' in #{JAVASCRIPT_MAIN_FILE}" \
             unless FONTAWESOME_ICONS.key?(name)
         end
-        out = src.gsub(placeholder){
+        inlined = src.gsub(placeholder){
           svg = File.read(File.join(ICONS_DIR, "#{$1}.svg"))
           %Q(<span class="icon fa-#{$1}" aria-hidden="true">#{svg}</span>).to_json
         }
-        File.write(File.join(MINIMAL_MISTAKES_DIR, JAVASCRIPT_MAIN_FILE), out)
-      end
-
-      desc "Generate a custom and minified version of minimal-mistake's main.js"
-      task :main => [:inline_icons] do
-        # remove useless dependencies from minified main.js
-        filename = File.join(MINIMAL_MISTAKES_DIR, 'package.json')
-        pkg = JSON.load(File.read(filename))
-        pkg['scripts']['uglify'] = pkg['scripts']['uglify']\
-          .split(/\s+/)
-          .select{|v| !MINIMAL_MISTAKES_EXCLUDED_SCRIPTS.any?{|s| v =~ /#{s}$/ }}
-          .join(' ')
-        File.write(filename, pkg.to_json)
-
-        # generate minified version of main.js
-        sh "npm --prefix #{MINIMAL_MISTAKES_DIR} run build:js"
-
-        # copy it in the assets directory
-        sh "cp #{File.join(MINIMAL_MISTAKES_DIR, JAVASCRIPT_FILE)} "\
-          << JAVASCRIPT_FILE
+        out, status = Open3.capture2("uglifyjs --compress --mangle", stdin_data: inlined)
+        abort "uglifyjs failed" unless status.success?
+        File.write(JAVASCRIPT_FILE, out)
       end
 
     end
     task :javascript => [
-      "generate:javascript:inline_icons",
       "generate:javascript:main",
     ]
 

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -122,6 +122,10 @@ html {
   }
 }
 
+@media (prefers-reduced-motion: no-preference) {
+  html { scroll-behavior: smooth; }
+}
+
 h1, h3, h4, h5, h6 {
   margin: 1.7em 0 0;
 }

--- a/assets/js/_main.js
+++ b/assets/js/_main.js
@@ -1,79 +1,16 @@
-/* ==========================================================================
-   jQuery plugin settings and other scripts
-   ========================================================================== */
-
-$(document).ready(function() {
-  // Sticky sidebar
-  var stickySideBar = function() {
-    var show =
-      $(".author__urls-wrapper button").length === 0
-        ? $(window).width() > 1024 // width should match $large Sass variable
-        : !$(".author__urls-wrapper button").is(":visible");
-    if (show) {
-      // fix
-      $(".sidebar").addClass("sticky");
-    } else {
-      // unfix
-      $(".sidebar").removeClass("sticky");
-    }
-  };
-
-  stickySideBar();
-
-  $(window).resize(function() {
-    stickySideBar();
+const followBtn = document.querySelector('.author__urls-wrapper button');
+if (followBtn) {
+  followBtn.addEventListener('click', function() {
+    document.querySelector('.author__urls').classList.toggle('is--visible');
   });
+}
 
-  // Follow menu drop down
-  $(".author__urls-wrapper button").on("click", function() {
-    $(".author__urls").toggleClass("is--visible");
-    $(".author__urls-wrapper button").toggleClass("open");
-  });
-
-  // Smooth scrolling
-  var scroll = new SmoothScroll('a[href*="#"]', {
-    offset: 20,
-    speed: 400,
-    speedAsDuration: true,
-    durationMax: 500
-  });
-
-  // Gumshoe scroll spy init
-  if($("nav.toc").length > 0) {
-    var spy = new Gumshoe("nav.toc a", {
-      // Active classes
-      navClass: "active", // applied to the nav list item
-      contentClass: "active", // applied to the content
-
-      // Nested navigation
-      nested: false, // if true, add classes to parents of active link
-      nestedClass: "active", // applied to the parent items
-
-      // Offset & reflow
-      offset: 20, // how far from the top of the page to activate a content area
-      reflow: true, // if true, listen for reflows
-
-      // Event support
-      events: true // if true, emit custom events
-    });
-  }
-
-  // add lightbox class to all image links
-  $(
-    "a[href$='.jpg'],a[href$='.jpeg'],a[href$='.JPG'],a[href$='.png'],a[href$='.gif']"
-  ).addClass("image-popup");
-
-  // Add anchors for headings
-  var linkIcon = '@@ICON:link@@'; // replaced at build time with an inline SVG span
-  $('.page__content').find('h1, h2, h3, h4, h5, h6').each(function() {
-    var id = $(this).attr('id');
-    if (id) {
-      var anchor = document.createElement("a");
-      anchor.className = 'header-link';
-      anchor.href = '#' + id;
-      anchor.innerHTML = '<span class="sr-only">Permalink</span>' + linkIcon;
-      anchor.title = "Permalink";
-      $(this).append(anchor);
-    }
-  });
+const linkIcon = '@@ICON:link@@'; // replaced at build time with an inline SVG span
+document.querySelectorAll('.page__content :is(h1,h2,h3,h4,h5,h6)[id]').forEach(function(h) {
+  const a = document.createElement('a');
+  a.className = 'header-link';
+  a.href = '#' + h.id;
+  a.title = 'Permalink';
+  a.innerHTML = '<span class="sr-only">Permalink</span>' + linkIcon;
+  h.appendChild(a);
 });


### PR DESCRIPTION
Rewrites _main.js as vanilla JS (follow-menu toggle + heading permalink anchors). Drops jQuery, greedy-navigation, throttle-debounce, smooth-scroll, and gumshoe. Smooth scrolling moves to CSS. Inlining and minification of main.min.js now run directly in the Rake task via Open3, making the minimal-mistakes git submodule (previously needed only for its npm build) and its Docker wiring redundant.