### PR TITLE
Strip out useless css

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -124,7 +124,7 @@ namespace :build do
           svg = File.read(File.join(ICONS_DIR, "#{$1}.svg"))
           %Q(<span class="icon fa-#{$1}" aria-hidden="true">#{svg}</span>).to_json
         }
-        out, status = Open3.capture2("uglifyjs --compress --mangle", stdin_data: inlined)
+        out, status = Open3.capture2("uglifyjs", "--compress", "--mangle", stdin_data: inlined)
         abort "uglifyjs failed" unless status.success?
         File.write(JAVASCRIPT_FILE, out)
       end

--- a/_config.yml
+++ b/_config.yml
@@ -109,6 +109,7 @@ kramdown:
 sass:
   sass_dir: _sass
   style: compressed # http://sass-lang.com/documentation/file.SASS_REFERENCE.html#output_style
+  sourcemap: never
   load_paths:
     - _sass
     - assets/css/

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -11,23 +11,7 @@
   document.documentElement.className = document.documentElement.className.replace(/\bno-js\b/g, '') + ' js ';
 </script>
 
-<!-- For all browsers -->
 <link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}">
-
-<!--[if IE]>
-  <style>
-    /* old IE unsupported flexbox fixes */
-    .greedy-nav .site-title {
-      padding-right: 3em;
-    }
-    .greedy-nav button {
-      position: absolute;
-      top: 0;
-      right: 0;
-      height: 100%;
-    }
-  </style>
-<![endif]-->
 
 {% if site.head_scripts %}
   {% for script in site.head_scripts %}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -14,7 +14,28 @@ $right-sidebar-padding-diff-wide: 200px;
 $keybase-color: #4c7ec7; // brand blue, overrides theme's default orange
 
 @import "minimal-mistakes/skins/{{ site.minimal_mistakes_skin | default: 'default' }}";
-@import "minimal-mistakes";
+
+// uncss doesn't reliably strip unused partials (magnific-popup, forms,
+// notices, search, archive) so they're omitted at the SCSS layer.
+@import "minimal-mistakes/copyright";
+@import "minimal-mistakes/variables";
+@import "minimal-mistakes/vendor/breakpoint/breakpoint";
+@include breakpoint-set("to ems", true);
+@import "minimal-mistakes/vendor/susy/susy";
+@import "minimal-mistakes/mixins";
+@import "minimal-mistakes/reset";
+@import "minimal-mistakes/base";
+@import "minimal-mistakes/tables";
+@import "minimal-mistakes/animations";
+@import "minimal-mistakes/buttons";
+@import "minimal-mistakes/masthead";
+@import "minimal-mistakes/navigation";
+@import "minimal-mistakes/footer";
+@import "minimal-mistakes/syntax";
+@import "minimal-mistakes/utilities";
+@import "minimal-mistakes/page";
+@import "minimal-mistakes/sidebar";
+@import "minimal-mistakes/print";
 
 // inline FA SVG icons (see _includes/icon.html)
 .icon {

--- a/assets/js/_main.js
+++ b/assets/js/_main.js
@@ -11,6 +11,7 @@ document.querySelectorAll('.page__content :is(h1,h2,h3,h4,h5,h6)[id]').forEach(f
   a.className = 'header-link';
   a.href = '#' + h.id;
   a.title = 'Permalink';
-  a.innerHTML = '<span class="sr-only">Permalink</span>' + linkIcon;
+  a.setAttribute('aria-label', 'Permalink');
+  a.innerHTML = linkIcon;
   h.appendChild(a);
 });


### PR DESCRIPTION
    Trim CSS bundle by cherry-picking minimal-mistakes partials

    Replaces `@import "minimal-mistakes"` with an explicit subset, skipping
    magnific-popup (no lightbox), forms, notices, search (disabled), and
    archive (all pages use `layout: single`). uncss leaves selectors from
    those partials in the output, so dropping them at the SCSS level is
    more effective than relying on post-build stripping: main.css shrinks
    from 68 KB to 19 KB (13 KB -> 4.4 KB gzipped).

    Also drops a dead IE conditional block from head.html, disables Sass
    sourcemap generation, replaces the JS-injected <span class="sr-only">
    with aria-label (the .sr-only rule is uncss-stripped, so the span would
    render its literal text when hovered), and switches the uglifyjs Open3
    call to argv form.